### PR TITLE
Update CMakeLists with minimal target linkage

### DIFF
--- a/vtkSurface/CMakeLists.txt
+++ b/vtkSurface/CMakeLists.txt
@@ -26,8 +26,23 @@ target_include_directories(vtkSurface
       $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}/ACVD/Common>
 )
 target_link_libraries(vtkSurface
-    PUBLIC
-        ${VTK_LIBRARIES}
+    PRIVATE
+        vtkCommonCore
+        vtkIOExport
+        vtkIOExportOpenGL2
+        vtkIOExportPDF
+        vtkIOGeometry
+        vtkIOImport
+        vtkIOLegacy
+        vtkIOMINC
+        vtkIOPLY
+        vtkInteractionStyle
+        vtkRenderingCore
+        vtkRenderingFreeType
+        vtkRenderingLabel
+        vtkRenderingOpenGL2
+        vtkRenderingContextOpenGL2
+        vtkViewsContext2D
 )
 
 set_target_properties(vtkSurface

--- a/vtkVolumeProcessing/CMakeLists.txt
+++ b/vtkVolumeProcessing/CMakeLists.txt
@@ -11,10 +11,6 @@ target_include_directories(vtkVolumeProcessing
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}/ACVD/VolumeProcessing>
 )
-target_link_libraries(vtkVolumeProcessing
-    PUBLIC
-        ${VTK_LIBRARIES}
-)
 
 set_target_properties(vtkVolumeProcessing
   PROPERTIES


### PR DESCRIPTION
Only link ACVD libraries against the VTK libraries they need.