### PR TITLE
Fix non deterministic output

### DIFF
--- a/vtkDiscreteRemeshing/include/vtkAnisotropicDiscreteRemeshing.h
+++ b/vtkDiscreteRemeshing/include/vtkAnisotropicDiscreteRemeshing.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /***************************************************************************
 vtkIsotropicDiscreteRemeshing.h  -  description
 -------------------
@@ -28,9 +30,6 @@ email                :
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
 
-#ifndef _VTKANISOTROPICDISCRETEREMESHING_H_
-#define _VTKANISOTROPICDISCRETEREMESHING_H_
-
 #include <vtkObjectFactory.h>
 
 #include "vtkDiscreteRemeshing.h"
@@ -55,7 +54,7 @@ public:
     static vtkAnisotropicDiscreteRemeshing* New()
     {
         // First try to	create the object from the vtkObjectFactory
-        vtkObject* ret =
+        auto* ret =
             vtkObjectFactory::CreateInstance("vtkAnisotropicDiscreteRemeshing");
         if (ret) {
             return (vtkAnisotropicDiscreteRemeshing*)ret;
@@ -68,5 +67,3 @@ protected:
     vtkAnisotropicDiscreteRemeshing() {}
     ~vtkAnisotropicDiscreteRemeshing() {}
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkAnisotropicMetricForClustering.h
+++ b/vtkDiscreteRemeshing/include/vtkAnisotropicMetricForClustering.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*=========================================================================
 
   Program:   vtkAnisotropicMetricForClustering.h
@@ -29,9 +31,6 @@
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
 
-#ifndef _VTKANISOTROPICMETRICFORCLUSTERING_H_
-#define _VTKANISOTROPICMETRICFORCLUSTERING_H_
-
 #include <vtkMath.h>
 #include <vtkTriangle.h>
 
@@ -53,7 +52,7 @@ public:
     void SetConstrainedClustering(int C) {}
 
     int IsCurvatureIndicatorNeeded() { return 1; }
-    int IsPrincipalDirectionsNeeded() { return (1); }
+    int IsPrincipalDirectionsNeeded() { return 1; }
 
     void SetCurvatureInfo(vtkDataArrayCollection* Info)
     {
@@ -424,5 +423,3 @@ private:
     // The array storing the items
     Item* Items;
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkClusteringExampleFile.h
+++ b/vtkDiscreteRemeshing/include/vtkClusteringExampleFile.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /***************************************************************************
                           vtkClusteringExampleFile.h  -  description
                              -------------------
@@ -26,8 +28,6 @@
 *  The fact that you are presently reading this means that you have had
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
-#ifndef _VTKCLUSTERINGEXAMPLEFILE_H_
-#define _VTKCLUSTERINGEXAMPLEFILE_H_
 
 #include <vtkObjectFactory.h>
 #include "vtkUniformClustering.h"
@@ -136,5 +136,3 @@ public:
     vtkMetricExample() {}
     ~vtkMetricExample() {}
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkDiscreteRemeshing.h
+++ b/vtkDiscreteRemeshing/include/vtkDiscreteRemeshing.h
@@ -433,24 +433,22 @@ void vtkDiscreteRemeshing<Metric>::SamplingPreProcessing()
         vtkPolyData* PrincipalDirectionsPolyData = nullptr;
         vtkDataArrayCollection* CurvatureCollection = nullptr;
 
-        if (false) {
-            auto Curvature = vtkCurvatureMeasure::New();
-            if (this->OriginalInput)
-                Curvature->SetInputData(this->OriginalInput);
-            else
-                Curvature->SetInputData(this->Input);
+        auto Curvature = vtkCurvatureMeasure::New();
+        if (this->OriginalInput)
+            Curvature->SetInputData(this->OriginalInput);
+        else
+            Curvature->SetInputData(this->Input);
 
-            Curvature->SetComputationMethod(1);
-            Curvature->SetElementsType(this->ClusteringType);
-            Curvature->SetComputePrincipalDirections(
-                this->MetricContext.IsPrincipalDirectionsNeeded());
+        Curvature->SetComputationMethod(1);
+        Curvature->SetElementsType(this->ClusteringType);
+        Curvature->SetComputePrincipalDirections(
+            this->MetricContext.IsPrincipalDirectionsNeeded());
 
-            CurvatureCollection = Curvature->GetCurvatureIndicator();
-            CurvatureCollection->Register(this);
+        CurvatureCollection = Curvature->GetCurvatureIndicator();
+        CurvatureCollection->Register(this);
 
-            CellsIndicators = (vtkDoubleArray*)CurvatureCollection->GetItem(0);
-            Curvature->Delete();
-        }
+        CellsIndicators = (vtkDoubleArray*)CurvatureCollection->GetItem(0);
+        Curvature->Delete();
 
         // now we have to interpolate the curvature measure when the input mesh
         // was subdivided
@@ -492,7 +490,6 @@ void vtkDiscreteRemeshing<Metric>::SamplingPreProcessing()
             }
             CurvatureCollection->ReplaceItem(0, CellsIndicators2);
             CellsIndicators2->Delete();
-            //			CellsIndicators->Delete();
             CellsIndicators = CellsIndicators2;
 
             cout << ".... Done" << endl;
@@ -569,9 +566,6 @@ void vtkDiscreteRemeshing<Metric>::CheckSubsamplingRatio()
 template <class Metric>
 void vtkDiscreteRemeshing<Metric>::Remesh()
 {
-    int i;
-    int Compute = 1;
-
     this->CheckSubsamplingRatio();
     this->SamplingPreProcessing();
 
@@ -799,49 +793,6 @@ void vtkDiscreteRemeshing<Metric>::AdjustRemeshedGeometry()
 template <class Metric>
 void vtkDiscreteRemeshing<Metric>::OptimizeOutputEdges()
 {
-    /*
-     * int  i,j;
-     * double P1[3],P2[3],P3[3],P4[3],P12[3],P34[3];
-     * vtkIdType v1,v2,v3,v4,f1,f2;
-     *
-     * double Quadric[10];
-     * double d1,d2;
-     *
-     * for  (i=0;i<this->Output->GetNumberOfEdges();i++)
-     * {
-     * Output->GetEdgeFaces(i,f1,f2);
-     * if ((f2>=0)&&(this->Input->IsEdgeManifold(i)==1))
-     * {
-     * Output->GetEdgeVertices(i,v1,v2);
-     * v3=Output->GetThirdPoint(f1,v1,v2);
-     * v4=Output->GetThirdPoint(f2,v1,v2);
-     * if (Output->IsEdge(v3,v4)==-1)
-     * {
-     * Output->GetPoints()->GetPoint(v1,P1);
-     * Output->GetPoints()->GetPoint(v2,P2);
-     * Output->GetPoints()->GetPoint(v3,P3);
-     * Output->GetPoints()->GetPoint(v4,P4);
-     *
-     * for  (j=0;j<10;j++)
-     * Quadric[j]=
-     * Quadrics[v1][j]
-     * +Quadrics[v2][j];
-     * //+Quadrics[v3][j]
-     * //+Quadrics[v4][j];
-     *
-     * for  (j=0;j<3;j++)
-     * {
-     * P12[j]=0.5*(P1[j]+P2[j]);
-     * P34[j]=0.5*(P3[j]+P4[j]);
-     * }
-     * d1=this->ComputeQuadraticDistance(P12,Quadric);
-     * d2=this->ComputeQuadraticDistance(P34,Quadric);
-     * if (d1*0.6>d2)
-     * Output->FlipEdge(i);
-     * }
-     * }
-     * }
-     */
 }
 
 template <class Metric>

--- a/vtkDiscreteRemeshing/include/vtkDiscreteRemeshing.h
+++ b/vtkDiscreteRemeshing/include/vtkDiscreteRemeshing.h
@@ -220,7 +220,7 @@ int vtkDiscreteRemeshing<Metric>::DetectNonManifoldOutputVertices(double Factor)
     for (int i = 0; i != ClustersWithIssues->GetNumberOfIds(); i++) {
         vtkIdType Cluster = ClustersWithIssues->GetId(i);
         vtkIdList* Items = ClusterItems[Cluster];
-        if (Items == 0)
+        if (Items == 0) {
             cout << "Warning : cluster " << Cluster << " seems empty!" << endl;
         }
         vtkIdType FirstSpareCluster =

--- a/vtkDiscreteRemeshing/include/vtkIsotropicDiscreteRemeshing.h
+++ b/vtkDiscreteRemeshing/include/vtkIsotropicDiscreteRemeshing.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /***************************************************************************
 vtkIsotropicDiscreteRemeshing.h  -  description
 -------------------
@@ -27,9 +29,6 @@ email                :
 *  The fact that you are presently reading this means that you have had
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
-
-#ifndef _VTKISOTROPICDISCRETEREMESHING_H_
-#define _VTKISOTROPICDISCRETEREMESHING_H_
 
 #include <vtkObjectFactory.h>
 
@@ -97,5 +96,3 @@ protected:
     vtkQIsotropicDiscreteRemeshing() {}
     ~vtkQIsotropicDiscreteRemeshing() {}
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkIsotropicMetricForClustering.h
+++ b/vtkDiscreteRemeshing/include/vtkIsotropicMetricForClustering.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
 Program:   Isotropic Metric for Clustering
@@ -30,9 +31,6 @@ Auteur:    Sebastien VALETTE
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
 
-#ifndef _VTKISOTROPICMETRICFORCLUSTERING_H_
-#define _VTKISOTROPICMETRICFORCLUSTERING_H_
-
 #include <vtkDataArrayCollection.h>
 #include <vtkTriangle.h>
 #include "vtkSurface.h"
@@ -52,12 +50,14 @@ public:
 
     int IsCurvatureIndicatorNeeded()
     {
-        if (this->Gradation > 0)
+        if (this->Gradation > 0) {
             return 1;
-        else
-            return (0);
+        } else {
+            return 0;
+        }
     }
-    int IsPrincipalDirectionsNeeded() { return (0); }
+
+    int IsPrincipalDirectionsNeeded() { return 0; }
 
     void SetCurvatureInfo(vtkDataArrayCollection* Info)
     {
@@ -66,6 +66,7 @@ public:
         this->CustomWeights = (vtkDoubleArray*)Info->GetItem(0);
         this->CustomWeights->Register(this->Object);
     }
+
     void SetGradation(double Gradation) { this->Gradation = Gradation; }
 
     double GetGradation() { return this->Gradation; }
@@ -92,7 +93,7 @@ public:
         double SWeight;
         double EnergyValue;
     };
-    int GetClusterRankDeficiency(Cluster* C) { return (0); }
+    int GetClusterRankDeficiency(Cluster* C) { return 0; }
     double GetClusterEnergy(Cluster* C) { return C->EnergyValue; }
     void ComputeClusterEnergy(Cluster* C)
     {
@@ -103,7 +104,7 @@ public:
     }
     double ComputeDistanceBetweenItemAndCluster(Item* I, Cluster* C)
     {
-        return (0);
+        return 0;
     }
 
     double ComputeDistanceBetweenItemAndPoint(Item* I, double* P1)
@@ -201,8 +202,9 @@ public:
         vtkIdType i;
         // Build the clusters
         Clusters = new Cluster[NumberOfClusters];
-        for (i = 0; i < NumberOfClusters; i++)
+        for (i = 0; i < NumberOfClusters; i++) {
             this->ResetCluster(Clusters + i);
+        }
 
         // Build the items
         if (ClusteringType == 0) {
@@ -283,5 +285,3 @@ private:
     // The array storing items
     Item* Items;
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkL21MetricForClustering.h
+++ b/vtkDiscreteRemeshing/include/vtkL21MetricForClustering.h
@@ -1,3 +1,4 @@
+#pragma once
 /*=========================================================================
 
 Program:   L2,1 Metric for Clustering
@@ -29,9 +30,6 @@ Auteur:    Sebastien VALETTE
 *  The fact that you are presently reading this means that you have had
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
-
-#ifndef _VTKL21METRICFORCLUSTERING_H_
-#define _VTKL21METRICFORCLUSTERING_H_
 
 #include <vtkIdList.h>
 #include <vtkMath.h>
@@ -323,5 +321,3 @@ private:
     double Factor;
     double Gradation;
 };
-
-#endif

--- a/vtkDiscreteRemeshing/include/vtkSurfaceClustering.h
+++ b/vtkDiscreteRemeshing/include/vtkSurfaceClustering.h
@@ -1,3 +1,4 @@
+#pragma once
 /***************************************************************************
                           vtkSurfaceClustering.h  -  description
                              -------------------
@@ -27,8 +28,6 @@
 *  The fact that you are presently reading this means that you have had
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
-#ifndef _VTKSURFACECLUSTERING_H_
-#define _VTKSURFACECLUSTERING_H_
 
 #include <vtkTriangleFilter.h>
 
@@ -148,4 +147,3 @@ vtkSurfaceClustering<Metric>::~vtkSurfaceClustering()
     if (this->Input)
         this->Input->Delete();
 }
-#endif

--- a/vtkSurface/include/vtkUniformClustering.h
+++ b/vtkSurface/include/vtkUniformClustering.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*=========================================================================
 
   Program:   Uniform Clustering (abstract class)
@@ -30,12 +32,9 @@
 *  knowledge of the CeCILL-B license and that you accept its terms.
 * ------------------------------------------------------------------------ */
 
-#ifndef _VTKUNIFORMCLUSTERING_H_
-#define _VTKUNIFORMCLUSTERING_H_
-
 #include <algorithm>
+#include <cstdlib>
 #include <queue>
-#include <random>
 
 #include <vtkBitArray.h>
 #include <vtkCellData.h>
@@ -1194,6 +1193,7 @@ template <class Metric, class EdgeType>
 void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
     vtkIdList* List, vtkIntArray* Sampling, int NumberOfRegions)
 {
+
     for (int i = 0; i < this->GetNumberOfItems(); i++)
         Sampling->SetValue(i, this->NumberOfClusters);
 
@@ -1205,11 +1205,16 @@ void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
     std::queue<int> IQueue;
 
     // shuffle the Ids ordering
-    std::random_device rd;
-    std::mt19937 g(rd());
+    struct LegacyRandom {
+        using result_type = int;
+        int operator()() { return std::rand(); }
+        constexpr static int max() { return RAND_MAX; }
+        constexpr static int min() { return 0; }
+    };
+    LegacyRandom randGen;
     for (int i = 0; i < NumberOfRemainingItems; i++)
         Items[i] = i;
-    std::shuffle(Items, Items + NumberOfRemainingItems, g);
+    std::shuffle(Items, Items + NumberOfRemainingItems, randGen);
 
     // compute total weight
     double SWeights = 0;
@@ -1275,7 +1280,7 @@ void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
         Items[i] = i;
     }
 
-    std::shuffle(Items, Items + NumberOfItems, g);
+    std::shuffle(Items, Items + NumberOfItems, randGen);
     FirstItem = 0;
     while (NumberOfRemainingRegions > 0) {
         Found = false;
@@ -1422,4 +1427,3 @@ vtkUniformClustering<Metric, EdgeType>::~vtkUniformClustering()
 
     this->EdgeList->Delete();
 }
-#endif

--- a/vtkSurface/include/vtkUniformClustering.h
+++ b/vtkSurface/include/vtkUniformClustering.h
@@ -33,8 +33,8 @@
 * ------------------------------------------------------------------------ */
 
 #include <algorithm>
-#include <cstdlib>
 #include <queue>
+#include <random>
 
 #include <vtkBitArray.h>
 #include <vtkCellData.h>
@@ -1193,7 +1193,6 @@ template <class Metric, class EdgeType>
 void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
     vtkIdList* List, vtkIntArray* Sampling, int NumberOfRegions)
 {
-
     for (int i = 0; i < this->GetNumberOfItems(); i++)
         Sampling->SetValue(i, this->NumberOfClusters);
 
@@ -1205,16 +1204,10 @@ void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
     std::queue<int> IQueue;
 
     // shuffle the Ids ordering
-    struct LegacyRandom {
-        using result_type = int;
-        int operator()() { return std::rand(); }
-        constexpr static int max() { return RAND_MAX; }
-        constexpr static int min() { return 0; }
-    };
-    LegacyRandom randGen;
+    std::mt19937 g;
     for (int i = 0; i < NumberOfRemainingItems; i++)
         Items[i] = i;
-    std::shuffle(Items, Items + NumberOfRemainingItems, randGen);
+    std::shuffle(Items, Items + NumberOfRemainingItems, g);
 
     // compute total weight
     double SWeights = 0;
@@ -1280,7 +1273,7 @@ void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
         Items[i] = i;
     }
 
-    std::shuffle(Items, Items + NumberOfItems, randGen);
+    std::shuffle(Items, Items + NumberOfItems, g);
     FirstItem = 0;
     while (NumberOfRemainingRegions > 0) {
         Found = false;

--- a/vtkSurface/include/vtkUniformClustering.h
+++ b/vtkSurface/include/vtkUniformClustering.h
@@ -1204,9 +1204,12 @@ void vtkUniformClustering<Metric, EdgeType>::ComputeInitialRandomSampling(
     std::queue<int> IQueue;
 
     // shuffle the Ids ordering
+    // We want these shuffled, but predictably, so that repeated run produce
+    // the same output. Don't seed the generator.
     std::mt19937 g;
-    for (int i = 0; i < NumberOfRemainingItems; i++)
+    for (int i = 0; i < NumberOfRemainingItems; i++) {
         Items[i] = i;
+    }
     std::shuffle(Items, Items + NumberOfRemainingItems, g);
 
     // compute total weight


### PR DESCRIPTION
In v1.0.1, repeated runs of `vtkIsotropicDiscreteRemeshing` would produce the same output. Somewhere along the way during cleanup for C++14, this stopped occurring. This restores this behavior.

In `vtkUniformClustering::ComputeInitialRandomSampling`, the vertices are shuffled twice. In previous versions, this was performed with `std::random_shuffle`, which was deprecated in C++14 and removed in C++17. That algorithm used `std::rand` without first setting a seed, the end result being a predictable shuffle. In v1.1.2, we replaced this with `std::shuffle` using a _seeded_ random engine. This caused the shuffling to not be repeatable, resulting in different results depending on the runs being performed. This removes the seed for the random engine, thus restoring the old behavior.

It's unclear if this is actually desirable behavior. It's probably fine and preferable for consistent results, though.